### PR TITLE
Add 'soft' dependencies

### DIFF
--- a/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
+++ b/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
@@ -145,7 +145,7 @@ namespace CobaltCoreModding.Components.Services
                             continue;
                         var loaded_list = loadedManifests.First(e => dependency.DependencyType.IsAssignableTo(e.Key)).Value;
                         //check if dependeny has been loaded.
-                        if (!loaded_list.Any(m => m.Name == dependency.DependencyName))
+                        if (!dependency.IgnoreIfMissing && !loaded_list.Any(m => m.Name == dependency.DependencyName))
                         {
                             failed = true;
                             break;
@@ -175,6 +175,8 @@ namespace CobaltCoreModding.Components.Services
                     //Determine missing dependency names
                     var missing_dependency_names = leftover.Dependencies.Where(d =>
                     {
+                        if(d.IgnoreIfMissing)
+                            return false;
                         if (!loadedManifests.Any(e => d.DependencyType.IsAssignableTo(e.Key)))
                             return false;
                         var loaded_list = loadedManifests.First(e => d.DependencyType.IsAssignableTo(e.Key)).Value;

--- a/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
+++ b/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
@@ -145,7 +145,7 @@ namespace CobaltCoreModding.Components.Services
                             continue;
                         var loaded_list = loadedManifests.First(e => dependency.DependencyType.IsAssignableTo(e.Key)).Value;
                         //check if dependeny has been loaded.
-                        if (!loaded_list.Any(m => m.Name.Equals(dependency.DependencyName, StringComparison.Ordinal)))
+                        if (!loaded_list.Any(m => m.Name == dependency.DependencyName))
                         {
                             failed = true;
                             break;
@@ -179,7 +179,7 @@ namespace CobaltCoreModding.Components.Services
                             return false;
                         var loaded_list = loadedManifests.First(e => d.DependencyType.IsAssignableTo(e.Key)).Value;
                         //check if dependeny has been loaded.
-                        return !loaded_list.Any(m => m.Name.Equals(d.DependencyName, StringComparison.Ordinal));
+                        return !loaded_list.Any(m => m.Name == d.DependencyName);
                     }).Select(e => e.DependencyName);
                     var mdn_list = string.Join("\n", missing_dependency_names);
                     missing_logger.LogCritical("The Manifest '{0}' is missing the following dependencies and thus cannot be loaded:\n {1}", leftover.Name, mdn_list);

--- a/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
+++ b/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
@@ -145,7 +145,7 @@ namespace CobaltCoreModding.Components.Services
                             continue;
                         var loaded_list = loadedManifests.First(e => dependency.DependencyType.IsAssignableTo(e.Key)).Value;
                         //check if dependeny has been loaded.
-                        if (!loaded_list.Any(m => string.Compare(m.Name, dependency.DependencyName) == 0))
+                        if (!loaded_list.Any(m => m.Name.Equals(dependency.DependencyName, StringComparison.Ordinal)))
                         {
                             failed = true;
                             break;
@@ -179,7 +179,7 @@ namespace CobaltCoreModding.Components.Services
                             return false;
                         var loaded_list = loadedManifests.First(e => d.DependencyType.IsAssignableTo(e.Key)).Value;
                         //check if dependeny has been loaded.
-                        return !loaded_list.Any(m => string.Compare(m.Name, d.DependencyName) == 0);
+                        return !loaded_list.Any(m => m.Name.Equals(d.DependencyName, StringComparison.Ordinal));
                     }).Select(e => e.DependencyName);
                     var mdn_list = string.Join("\n", missing_dependency_names);
                     missing_logger.LogCritical("The Manifest '{0}' is missing the following dependencies and thus cannot be loaded:\n {1}", leftover.Name, mdn_list);

--- a/CobaltCoreModding.Definitions/Dependency.cs
+++ b/CobaltCoreModding.Definitions/Dependency.cs
@@ -13,10 +13,23 @@ namespace CobaltCoreModding.Definitions
         /// <param name="dependencyName"></param>
         /// <param name="dependencyType"></param>
         /// <see cref="DependencyEntry{T}"/>
-        protected DependencyEntry(string dependencyName, Type dependencyType)
+        [Obsolete("Use the 3-arg overload instead.")]
+        protected DependencyEntry(string dependencyName, Type dependencyType) : this(dependencyName, dependencyType, false)
+        {
+        }
+
+        /// <summary>
+        /// Closed constructor to prevent missconstruction, use DependencyEntry{T} for construction.
+        /// </summary>
+        /// <param name="dependencyName"></param>
+        /// <param name="dependencyType"></param>
+        /// <param name="ignoreIfMissing"></param>
+        /// <see cref="DependencyEntry{T}"/>
+        protected DependencyEntry(string dependencyName, Type dependencyType, bool ignoreIfMissing = false)
         {
             DependencyName = dependencyName;
             DependencyType = dependencyType;
+            IgnoreIfMissing = ignoreIfMissing;
         }
 
         /// <summary>
@@ -29,6 +42,8 @@ namespace CobaltCoreModding.Definitions
         /// In case a manifest for example implements Sprites, Artifacts, Events, etc, but our dependeny is only on an artifact.
         /// </summary>
         public Type DependencyType { get; init; }
+
+        public bool IgnoreIfMissing { get; init; }
     }
 
     /// <summary>
@@ -41,7 +56,17 @@ namespace CobaltCoreModding.Definitions
         /// A raw constructor
         /// </summary>
         /// <param name="dependencyName">the name of the dependency manifest.</param>
-        public DependencyEntry(string dependencyName) : base(dependencyName, typeof(T))
+        [Obsolete("Use the 2-arg overload instead.")]
+        public DependencyEntry(string dependencyName) : this(dependencyName, false)
+        {
+        }
+
+        /// <summary>
+        /// A raw constructor
+        /// </summary>
+        /// <param name="dependencyName">the name of the dependency manifest.</param>
+        /// <param name="ignoreIfMissing">If <c>true</c>, the mod will continue to load if the dependency is missing</param>
+        public DependencyEntry(string dependencyName, bool ignoreIfMissing = false) : base(dependencyName, typeof(T), ignoreIfMissing)
         {
         }
 
@@ -49,7 +74,18 @@ namespace CobaltCoreModding.Definitions
         /// For even more stricter control use this
         /// </summary>
         /// <param name="manifest">the manifest to which we are dependent.</param>
-        public DependencyEntry(T manifest) : base(manifest.Name, typeof(T))
+        [Obsolete("Use the 2-arg overload instead.")]
+        public DependencyEntry(T manifest) : this(manifest, false)
+        {
+        }
+
+
+        /// <summary>
+        /// For even more stricter control use this
+        /// </summary>
+        /// <param name="manifest">the manifest to which we are dependent.</param>
+        /// <param name="ignoreIfMissing">If <c>true</c>, the mod will continue to load if the dependency is missing</param>
+        public DependencyEntry(T manifest, bool ignoreIfMissing = false) : base(manifest.Name, typeof(T), ignoreIfMissing)
         {
         }
     }


### PR DESCRIPTION
'Soft' dependencies affect the load order iff the depended-on mod is present, but do not prevent loading.

---

For backwards-compatibility purposes, I have intentionally not removed the previous `DependencyEntry` constructors, as doing so would break ABI. I recommend removing them with the next breaking change (if any).