### PR TITLE
Compare AssemblyName.FullName instead of AssemblyName instances

### DIFF
--- a/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
+++ b/CobaltCoreModding.Components/Services/ModAssemblyHandler.cs
@@ -293,7 +293,7 @@ namespace CobaltCoreModding.Components.Services
         private Assembly? ModContext_Resolving(AssemblyLoadContext context, AssemblyName assemblyName)
         {
             //Mods should either cross reference another mod.
-            Assembly? result = modAssemblies.Concat(new Assembly[] { CobaltCoreAssembly }).FirstOrDefault(e => e.GetName().Equals(assemblyName));
+            Assembly? result = modAssemblies.Concat(new Assembly[] { CobaltCoreAssembly }).FirstOrDefault(e => e.GetName().FullName == assemblyName.FullName);
             //or an internal dependency, which we will load here to its context to avoid collision between mods.
             if (result == null)
             {


### PR DESCRIPTION
The old comparison always failed, since AssemblyName.Equals is just object.Equals, which purely does reference equality.

This is slightly better, in that we now at least support perfect matches; but version / culture differences still trip this up.