### PR TITLE
External SaySwitch, Story Injectors

### DIFF
--- a/CobaltCoreModding.Components/Services/StoryRegistry.cs
+++ b/CobaltCoreModding.Components/Services/StoryRegistry.cs
@@ -2,7 +2,9 @@
 using CobaltCoreModding.Definitions.ExternalItems;
 using CobaltCoreModding.Definitions.ModContactPoints;
 using Microsoft.Extensions.Logging;
+using Mono.Cecil.Cil;
 using System.Collections;
+using System.Net.NetworkInformation;
 using System.Reflection;
 
 namespace CobaltCoreModding.Components.Services
@@ -12,8 +14,24 @@ namespace CobaltCoreModding.Components.Services
         private static readonly Dictionary<string, Tuple<MethodInfo, bool>> registeredChoices = new Dictionary<string, Tuple<MethodInfo, bool>>();
         private static readonly Dictionary<string, Tuple<MethodInfo, bool>> registeredCommands = new Dictionary<string, Tuple<MethodInfo, bool>>();
         private static readonly Dictionary<string, ExternalStory> registeredStories = new Dictionary<string, ExternalStory>();
+        private static readonly List<ExternalStoryInjector> registeredInjectors = new List<ExternalStoryInjector>();
         private static ILogger<StoryRegistry>? logger;
         private readonly ModAssemblyHandler modAssemblyHandler;
+
+        private static FieldInfo? _saySwitch_field_info;
+
+        private static FieldInfo SaySwitchLinesFielInfo
+        {  
+            get
+            {
+                if (_saySwitch_field_info == null)
+                {
+                    _saySwitch_field_info = TypesAndEnums.SaySwitchType.GetField("lines") ?? throw new Exception("Cannot find SaySwitch.lines");
+                }
+
+                return _saySwitch_field_info;
+            }
+        }
 
         public StoryRegistry(ILogger<StoryRegistry>? logger, ModAssemblyHandler mah)
         {
@@ -58,6 +76,7 @@ namespace CobaltCoreModding.Components.Services
             var story = TypesAndEnums.DbType.GetField("story")?.GetValue(null) ?? throw new Exception("Cannot find DB.story");
             var stories_dict = TypesAndEnums.StoryType.GetField("all")?.GetValue(story) as IDictionary ?? throw new Exception("Cannot find Story.all");
             var node_lines_field_info = TypesAndEnums.StoryNodeType.GetField("lines") ?? throw new Exception("Cannot find StoryNode.lines");
+            
 
             foreach (ExternalStory s in registeredStories.Values)
             {
@@ -69,18 +88,13 @@ namespace CobaltCoreModding.Components.Services
 
                     foreach (var instruction in s.Instructions)
                     {
-                        //convert external says to native say.
                         if (instruction is ExternalStory.ExternalSay extSay)
                         {
-                            dynamic nativeSay = Activator.CreateInstance(TypesAndEnums.SayType) ?? throw new Exception("Cannot create instance of class Say");
-                            nativeSay.hash = extSay.Hash;
-                            nativeSay.who = extSay.Who;
-                            nativeSay.loopTag = extSay.LoopTag;
-                            nativeSay.ifCrew = extSay.IfCrew;
-                            nativeSay.delay = extSay.Delay;
-                            nativeSay.choiceFunc = extSay.ChoiceFunc;
-                            nativeSay.flipped = extSay.Flipped;
-                            node_lines_field.Add(nativeSay);
+                            node_lines_field.Add(ExternalToNativeSay(extSay));
+                        }
+                        else if (instruction is ExternalStory.ExternalSaySwitch extSaySwitch)
+                        {
+                            node_lines_field.Add(ExternalToNativeSaySwitch(extSaySwitch));
                         }
                         else
                         {
@@ -95,6 +109,121 @@ namespace CobaltCoreModding.Components.Services
 
                 stories_dict.Add(s.GlobalName, s.StoryNode);
             }
+
+            foreach (ExternalStoryInjector injector in registeredInjectors)
+            {
+                if (!stories_dict.Contains(injector.StoryName))
+                {
+                    throw new Exception(String.Format("Cannot find story node {0} for injection", injector.StoryName));
+                }
+
+                var injectedNode = stories_dict[injector.StoryName];
+
+                if (injector.advancedInjector != null)
+                {
+                    injector.advancedInjector.Invoke(injectedNode);
+                }
+                else if (injector.Instructions != null)
+                {
+                    var injected_node_lines = node_lines_field_info.GetValue(injectedNode) as IList ?? throw new Exception("Cannot find value of StoryNode.lines");
+                    dynamic injected_instructions = Activator.CreateInstance(typeof(List<>).MakeGenericType(TypesAndEnums.InstructionType), new object[] { });
+
+                    foreach (var instruction in injector.Instructions)
+                    {
+                        if (instruction is ExternalStory.ExternalSay extSay)
+                        {
+                            injected_instructions.Add(ExternalToNativeSay(extSay));
+                        }
+                        else if (instruction is ExternalStory.ExternalSaySwitch extSaySwitch)
+                        {
+                            injected_instructions.Add(ExternalToNativeSaySwitch(extSaySwitch));
+                        }
+                        else
+                        {
+                            if (!instruction.GetType().IsSubclassOf(TypesAndEnums.InstructionType))
+                            {
+                                throw new Exception(String.Format("Cannot add instance of class {0} to Story Node {1} as it does not inherit from class Instruction", instruction.GetType().Name, injector.StoryName));
+                            }
+                            injected_instructions.Add(instruction);
+                        }
+                    }
+
+                    int counter = 0;
+                    switch (injector.quickInjection)
+                    {
+                        case ExternalStoryInjector.QuickInjection.SaySwitch:
+                            for (int i = 0; i < injected_node_lines.Count; i++)
+                            {
+                                if (injected_node_lines[i].GetType() == TypesAndEnums.SaySwitchType)
+                                {
+                                    if (counter == injector.targetIndex)
+                                    {
+                                        var saySwitchLines = SaySwitchLinesFielInfo.GetValue(injected_node_lines[i]) as IList ?? throw new Exception("Cannot find value of field SaySwitch.lines");
+                                        InsertRange(0, saySwitchLines, injected_instructions);
+                                        break;
+                                    }
+                                    counter++;
+                                }
+                            }
+                            break;
+                        case ExternalStoryInjector.QuickInjection.Beginning:
+                            InsertRange(Math.Min(injector.targetIndex, injected_node_lines.Count), injected_node_lines, injected_instructions);
+                            break;
+                        case ExternalStoryInjector.QuickInjection.End:
+                            InsertRange(Math.Max(injected_node_lines.Count - injector.targetIndex, 0), injected_node_lines, injected_instructions);
+                            break;
+                    }
+                }
+            }
+        }
+
+        private static void InsertRange (int index, IList list, IEnumerable items)
+        {
+            foreach (var item in items)
+            {
+                list.Insert(index, item);
+                index++;
+            }
+        }
+
+        //convert external says to native say.
+        private static dynamic ExternalToNativeSay(ExternalStory.ExternalSay extSay)
+        {
+            dynamic nativeSay = Activator.CreateInstance(TypesAndEnums.SayType) ?? throw new Exception("Cannot create instance of class Say");
+            nativeSay.hash = extSay.Hash;
+            nativeSay.who = extSay.Who;
+            nativeSay.loopTag = extSay.LoopTag;
+            nativeSay.ifCrew = extSay.IfCrew;
+            nativeSay.delay = extSay.Delay;
+            nativeSay.choiceFunc = extSay.ChoiceFunc;
+            nativeSay.flipped = extSay.Flipped;
+
+            return nativeSay;
+        }
+
+        private static dynamic ExternalToNativeSaySwitch(ExternalStory.ExternalSaySwitch extSaySwitch)
+        {
+            dynamic nativeSwitch = Activator.CreateInstance(TypesAndEnums.SaySwitchType) ?? throw new Exception("Cannot create instance of class SaySwitch");
+            dynamic list = Activator.CreateInstance(typeof(List<>).MakeGenericType(TypesAndEnums.SayType), new object[] { });
+
+            foreach (var saySwitchInstruction in extSaySwitch.lines)
+            {
+                if (saySwitchInstruction is ExternalStory.ExternalSay)
+                {
+                    list.Add(ExternalToNativeSay(saySwitchInstruction));
+                }
+                else if (saySwitchInstruction.GetType().IsSubclassOf(TypesAndEnums.SayType))
+                {
+                    list.Add(saySwitchInstruction);
+                }
+                else
+                {
+                    throw new Exception(String.Format("Cannot add instance of class {0} to SaySwitch as it does not inherit from class Say", saySwitchInstruction.GetType().Name));
+                }
+            }
+
+            SaySwitchLinesFielInfo.SetValue(nativeSwitch, list);
+            return nativeSwitch;
         }
 
         public void LoadManifests()
@@ -177,6 +306,22 @@ namespace CobaltCoreModding.Components.Services
                     {
                         continue;
                     }
+                    if (instruction is ExternalStory.ExternalSaySwitch saySwitch)
+                    {
+                        foreach (var switchInstruction in saySwitch.lines)
+                        {
+                            if (switchInstruction is ExternalStory.ExternalSay)
+                            {
+                                continue;
+                            }
+                            if (!switchInstruction.GetType().IsSubclassOf(TypesAndEnums.SayType))
+                            {
+                                logger?.LogWarning("Cannot add instance of class {0} to ExternalSaySwitch in Story Node {1} as it does not inherit from class Say. It is also not an externalStory.Say instruction type", instruction.GetType().Name, story.GlobalName);
+                                return false;
+                            }
+                        }
+                        continue;
+                    }
                     if (!instruction.GetType().IsSubclassOf(TypesAndEnums.InstructionType))
                     {
                         logger?.LogWarning("Cannot add instance of class {0} to Story Node {1} as it does not inherit from class Instruction. It is also not an external.story instruction type", instruction.GetType().Name, story.GlobalName);
@@ -185,6 +330,68 @@ namespace CobaltCoreModding.Components.Services
                 }
             }
             registeredStories.Add(story.GlobalName, story);
+
+            return true;
+        }
+
+        public bool RegisterInjector(ExternalStoryInjector injector)
+        {
+            if (string.IsNullOrWhiteSpace(injector.StoryName))
+            {
+                logger?.LogCritical("Attempted to register injector with no target!");
+                return false;
+            }
+
+            //validate lines
+            if (injector.Instructions != null)
+            {
+                if (injector.quickInjection == ExternalStoryInjector.QuickInjection.SaySwitch)
+                {
+                    foreach (var instruction in injector.Instructions)
+                    {
+                        if (instruction is ExternalStory.ExternalSay)
+                        {
+                            continue;
+                        }
+                        if (!instruction.GetType().IsSubclassOf(TypesAndEnums.SayType))
+                        {
+                            logger?.LogWarning("Cannot inject instance of class {0} to SaySwitch in StoryNode {1} as it does not inherit from class Say. It is also not an ExternalStory.ExternalSay instruction type", instruction.GetType().Name, injector.StoryName);
+                            return false;
+                        }
+                    }
+                }
+                else
+                {
+                    foreach (var instruction in injector.Instructions)
+                    {
+                        if (instruction is ExternalStory.ExternalSay)
+                        {
+                            continue;
+                        }
+                        if (instruction is ExternalStory.ExternalSaySwitch saySwitch)
+                        {
+                            foreach (var switchInstruction in saySwitch.lines)
+                            {
+                                if (switchInstruction is ExternalStory.ExternalSay)
+                                {
+                                    continue;
+                                }
+                                if (!switchInstruction.GetType().IsSubclassOf(TypesAndEnums.SayType))
+                                {
+                                    logger?.LogWarning("Cannot add instance of class {0} to ExternalSaySwitch in Story Node {1} as it does not inherit from class Say. It is also not an externalStory.Say instruction type", instruction.GetType().Name, injector.StoryName);
+                                    return false;
+                                }
+                            }
+                        }
+                        if (!instruction.GetType().IsSubclassOf(TypesAndEnums.InstructionType))
+                        {
+                            logger?.LogWarning("Cannot inject instance of class {0} to Story Node {1} as it does not inherit from class Instruction. It is also not an external.story instruction type", instruction.GetType().Name, injector.StoryName);
+                            return false;
+                        }
+                    }
+                }
+            }
+            registeredInjectors.Add(injector);
 
             return true;
         }
@@ -204,6 +411,17 @@ namespace CobaltCoreModding.Components.Services
                 {
                     if (!result.TryAdd(line.Key, line.Value))
                         logger?.LogWarning("Story {0} cannot register line because key {1} already added somehow", s.GlobalName, line.Key);
+                }
+            }
+
+            foreach (var i in registeredInjectors)
+            {
+                i.GetLocalisation(locale, out Dictionary<string, string> lines);
+
+                foreach (KeyValuePair<string, string> line in lines)
+                {
+                    if (!result.TryAdd(line.Key, line.Value))
+                        logger?.LogWarning("Story {0} cannot register line because key {1} already added somehow", i.StoryName, line.Key);
                 }
             }
         }

--- a/CobaltCoreModding.Components/Utils/TypesAndEnums.cs
+++ b/CobaltCoreModding.Components/Utils/TypesAndEnums.cs
@@ -49,6 +49,7 @@ namespace CobaltCoreModding.Components.Utils
         private static Type? __story_node_type = null;
         private static Type? __story_type = null;
         private static Type? __say_type = null;
+        private static Type? __say_switch_type = null;
         private static Type? __instruction_type = null;
 
         public static Type PTypeType
@@ -339,6 +340,16 @@ namespace CobaltCoreModding.Components.Utils
                 if (__say_type != null)
                     return __say_type;
                 return __say_type = CobaltCoreHandler.CobaltCoreAssembly?.GetType("Say") ?? throw new Exception("Say type not found");
+            }
+        }
+
+        public static Type SaySwitchType
+        {
+            get
+            {
+                if (__say_switch_type != null)
+                    return __say_switch_type;
+                return __say_switch_type = CobaltCoreHandler.CobaltCoreAssembly?.GetType("SaySwitch") ?? throw new Exception("SaySwitch type not found");
             }
         }
 

--- a/CobaltCoreModding.Definitions/ExternalItems/ExternalStory.cs
+++ b/CobaltCoreModding.Definitions/ExternalItems/ExternalStory.cs
@@ -48,7 +48,24 @@ namespace CobaltCoreModding.Definitions.ExternalItems
                     {
                         AddLocalisation(say.Hash, say.What);
                     }
+                    if (instruction is ExternalSaySwitch sswitch)
+                    {
+                        foreach (ExternalSay extSay in sswitch.lines)
+                        {
+                            AddLocalisation(extSay.Hash, extSay.What);
+                        }
+                    }
                 }
+            }
+        }
+
+        public class ExternalSaySwitch
+        {
+            public List<ExternalSay> lines;
+
+            public ExternalSaySwitch(List<ExternalSay> lines)
+            {
+                this.lines = lines;
             }
         }
 

--- a/CobaltCoreModding.Definitions/ExternalItems/ExternalStoryInjector.cs
+++ b/CobaltCoreModding.Definitions/ExternalItems/ExternalStoryInjector.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using static CobaltCoreModding.Definitions.ExternalItems.ExternalStory;
+
+namespace CobaltCoreModding.Definitions.ExternalItems
+{
+    public class ExternalStoryInjector
+    {
+        private readonly Dictionary<string, Dictionary<string, string>> localisations = new Dictionary<string, Dictionary<string, string>>();
+        public string StoryName { get; init; }
+        public int targetIndex;
+        public QuickInjection quickInjection;
+        public IEnumerable<object>? Instructions;
+
+        public delegate void InjectionMethod(object node);
+        public InjectionMethod? advancedInjector;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="storyName">the global name of the existing story in which you want to inject instructions.</param>
+        /// <param name="quickInjection">Define the relative place where the injection will take place.</param>
+        /// <param name="targetIndex">A general parameter that serves as offset for the injection. offset toward the end for QuickInjection.Beginning, offset toward the beginning for QuickInjection.End, or skips Sayswitches for QuickInjection.SaySwitch </param>
+        /// <param name="instructions">instructions which will be injected into the story. mix of native instruction objects and externalstory instructions like externalsay. QuickInjection.SaySwitch only accepts Say and ExternalSay instructions !</param>
+        public ExternalStoryInjector(string storyName, QuickInjection quickInjection, int targetIndex, IEnumerable<object> instructions)
+        {
+            StoryName = storyName;
+            this.targetIndex = targetIndex;
+            this.quickInjection = quickInjection;
+
+            this.Instructions = instructions.ToArray();
+            if (Instructions != null)
+            {
+                //have instructions based translation registered.
+                foreach (var instruction in this.Instructions)
+                {
+                    if (instruction is ExternalSay say)
+                    {
+                        AddLocalisation(say.Hash, say.What);
+                    }
+                    if (instruction is ExternalSaySwitch sswitch)
+                    {
+                        foreach (ExternalSay extSay in sswitch.lines)
+                        {
+                            AddLocalisation(extSay.Hash, extSay.What);
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="storyName">the global name of the existing story in which you want to inject instructions.</param>
+        public ExternalStoryInjector(string storyName, InjectionMethod injector) 
+        {
+            StoryName = storyName;
+            this.advancedInjector = injector;
+        }
+
+        public enum QuickInjection
+        {
+            Beginning,
+            End,
+            SaySwitch
+        }
+
+        /// <summary>
+        /// Use to add non native localisations for an instruction.
+        /// </summary>
+        /// <param name="lineHash">the hash of the line</param>
+        /// <param name="text"></param>
+        /// <param name="localisation"></param>
+        public void AddLocalisation(string lineHash, string text, string localisation = "en")
+        {
+            localisations.TryAdd(localisation, new Dictionary<string, string>());
+            string key = String.Join(":", StoryName, lineHash);
+            if (!localisations[localisation].TryAdd(key, text))
+                localisations[localisation][key] = text;
+        }
+
+        public void GetLocalisation(string localisation, out Dictionary<string, string> lines)
+        {
+            Dictionary<string, string>? maybe_lines;
+            if (!localisations.TryGetValue(localisation, out maybe_lines))
+                if (!localisations.TryGetValue("en", out maybe_lines))
+                {
+                    lines = new Dictionary<string, string>();
+                    return;
+                }
+            lines = maybe_lines;
+        }
+    }
+}

--- a/CobaltCoreModding.Definitions/ItemLookups/IEnemyLookup.cs
+++ b/CobaltCoreModding.Definitions/ItemLookups/IEnemyLookup.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CobaltCoreModding.Definitions.ItemLookups
+{
+    public interface IEnemyLookup
+    {
+        public object LookupEnemy(string globalName);
+    }
+}

--- a/CobaltCoreModding.Definitions/ModContactPoints/IStoryRegistry.cs
+++ b/CobaltCoreModding.Definitions/ModContactPoints/IStoryRegistry.cs
@@ -13,5 +13,6 @@ namespace CobaltCoreModding.Definitions.ModContactPoints
         public bool RegisterStory(ExternalStory story);
         public bool RegisterChoice(string key, MethodInfo choice, bool intendedOverride = false);
         public bool RegisterCommand(string key, MethodInfo command, bool intendedOverride = false);
+        public bool RegisterInjector(ExternalStoryInjector injector);
     }
 }

--- a/DemoMod/DemoStoryManifest.cs
+++ b/DemoMod/DemoStoryManifest.cs
@@ -56,30 +56,31 @@ namespace DemoMod
                         who = "peri",
                         hash = "0" // a string that must be unique to your story, used to fetch localisation 
                     },
-                    new SaySwitch() /* this is used to randomly pick a valid options among the listed Says.
-                                     * Currently doesn't support ExternalStory.ExternalSay, so you'll have to input localisation and hashing by hand.*/
+                    new ExternalStory.ExternalSaySwitch( new List<ExternalStory.ExternalSay>() // this is used to randomly pick a valid options among the listed Says.
                     {
-                        lines = new List<Say> { 
-                            new Say() { 
-                                who = "max",
-                                hash = "maxSwitch"
-                            },
-                            new Say() {
-                                who = "eunice",
-                                hash = "drakeSwitch"
-                            },
-                            new Say() {
-                                who = "books",
-                                hash = "booksSwitch"
-                            },
-                        }
-                    }
+                        new ExternalStory.ExternalSay()
+                        {
+                            Who = "dizzy",
+                            What = "A !",
+                            LoopTag = "squint" 
+                        },
+                        new ExternalStory.ExternalSay()
+                        {
+                            Who = "eunice",
+                            What = "B !",
+                            LoopTag = "squint"
+                        },
+                        new ExternalStory.ExternalSay()
+                        {
+                            Who = "goat",
+                            What = "C !",
+                            LoopTag = "squint"
+                        },
+                    }) 
+                                     
                 }
             );
             exampleShout.AddLocalisation("0", "Example native shout !"); // setting the localisation for peri's shout using the native way
-            exampleShout.AddLocalisation("maxSwitch", "Rad");
-            exampleShout.AddLocalisation("drakeSwitch", "Im super mean btw");
-            exampleShout.AddLocalisation("booksSwitch", "*eats crystal shard*");
 
             storyRegistry.RegisterStory(exampleShout);
 
@@ -177,6 +178,33 @@ namespace DemoMod
                     }
                 );
             storyRegistry.RegisterStory(exampleEventOutcome_2);
+
+            // Story injectors below, allows you to actively edit/insert stuff from existing story in a non destructive way !
+
+            var injector = new ExternalStoryInjector("AbandonedShipyard", // the story in which to insert stuff
+                                                    ExternalStoryInjector.QuickInjection.Beginning, // from where to insert stuff. SaySwitch will insert your stuff in the nth SaySwitch, where n is targetIndex 
+                                                    1, // an index that offset the quick injection location. in this case, we're inserting 1 away from the beginning.
+                                                    new List<object>() // the stuff you want to insert
+            {
+                new ExternalStory.ExternalSay()
+                {
+                    Who = "comp",
+                    What = "Hey, i'm not supposed to say that !"
+                }
+            });
+
+            storyRegistry.RegisterInjector(injector);
+
+
+            // Advanced injectors let you hook a method that will receive the StoryNode during DB injection time, allowing you to modify it however you wish !
+
+            var advancedInjector = new ExternalStoryInjector("AbandonedShipyard", (node) =>
+            {
+                StoryNode s = node as StoryNode;
+
+
+            });
+            storyRegistry.RegisterInjector(advancedInjector);
         }
     }
 }


### PR DESCRIPTION
Added ExternalStory.ExternalSaySwitch, which allows the creation of SaySwitches that uses ExternalStory.ExternalSay
Added Story injectors, allowing automatic/advanced injections of instructions into existing dialogues