### PR TITLE
Add AttributeUsage to IgnoreModComponentAttribute

### DIFF
--- a/CobaltCoreModding.Definitions/IgnoreModComponentAttribute.cs
+++ b/CobaltCoreModding.Definitions/IgnoreModComponentAttribute.cs
@@ -3,6 +3,7 @@
     /// <summary>
     /// The native loading functions of the mod loader will pass any class with this attribute.
     /// </summary>
+    [AttributeUsage(AttributeTargets.Class)]
     public class IgnoreModComponentAttribute : Attribute
     {
     }


### PR DESCRIPTION
Shuts up a warning during building and makes it clear that this attribute isn't usable on anything that isn't a class.